### PR TITLE
Install version 4.5.12 by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
   - distro: ubuntu1804
   - distro: ubuntu1604
   - distro: ubuntu1404
-  - distro: ubuntu1204
   - distro: debian9
   - distro: debian8
   - distro: centos7

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,10 +10,14 @@ miniconda_mirror: "https://repo.continuum.io/miniconda"
 miniconda_python_ver: 3
 
 # miniconda version
-miniconda_ver: "4.5.4"
+miniconda_ver: "4.5.12"
 
 # miniconda checksums
 miniconda_checksums:
+  Miniconda2-4.5.12-Linux-x86_64.sh: "md5:4be03f925e992a8eda03758b72a77298"
+  Miniconda3-4.5.12-Linux-x86_64.sh: "md5:866ae9dff53ad0874e1d1a60b1ad1ef8"
+  Miniconda2-4.5.11-Linux-x86_64.sh: "md5:458324438b7b0e5afcc272b63d44195d"
+  Miniconda3-4.5.11-Linux-x86_64.sh: "md5:e1045ee415162f944b6aebfe560b8fee"
   Miniconda2-4.5.4-Linux-x86_64.sh: "md5:8a1c02f6941d8778f8afad7328265cf5"
   Miniconda3-4.5.4-Linux-x86_64.sh: "md5:a946ea1d0c4a642ddf0c3a26a18bb16d"
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,7 +13,6 @@ galaxy_info:
         - bionic
         - xenial
         - trusty
-        - precise
     - name: Debian
       versions:
         - stretch


### PR DESCRIPTION
* Add md5 checksums for versions 4.5.11 and 4.5.12
* Remove support for Ubuntu 12.04